### PR TITLE
Extract all couts into printMessage method

### DIFF
--- a/include/minefield/exit_game.h
+++ b/include/minefield/exit_game.h
@@ -1,4 +1,4 @@
 #pragma once
 #include "minefield.h"
 
-NextState exitGame(GameContext &context);
+NextState exitGame(GameContext& context);

--- a/include/minefield/minefield.h
+++ b/include/minefield/minefield.h
@@ -59,4 +59,5 @@ struct GameContext
     Board board;
     std::vector<Player> players;
     RandomGenerationFn randomGenerator = RandomGenerator{};
+    std::ostream& outputStream = std::cout;
 };

--- a/include/minefield/process_mine_detection.h
+++ b/include/minefield/process_mine_detection.h
@@ -1,13 +1,14 @@
 #pragma once
 #include "minefield.h"
-#include <vector>
+
+#include <set>
 #include <string>
 #include <unordered_set>
-#include <set>
+#include <vector>
 
-NextState processMineDetection(GameContext &context);
-std::set<unsigned int> getExplodedMines(const std::vector<unsigned int> &minesToCheck, const std::vector<unsigned int> &minesToMatchAgainst);
-void disableUsedCells(std::unordered_set<unsigned int> usedCells, Board &board);
-void disableCell(std::vector<int> &cells, int cell);
-void resizePlayerMineCount(std::unordered_map<Player *, int> playerExplodedMineCount);
-void printExplodedMinesMessage(const std::set<unsigned int> &explodedMines, const std::string &playerName);
+NextState processMineDetection(GameContext& context);
+std::set<unsigned int> getExplodedMines(std::vector<unsigned int> const& minesToCheck, std::vector<unsigned int> const& minesToMatchAgainst);
+void disableUsedCells(std::unordered_set<unsigned int> usedCells, Board& board);
+void disableCell(std::vector<int>& cells, int cell);
+void resizePlayerMineCount(std::unordered_map<Player*, int> playerExplodedMineCount);
+void printExplodedMinesMessage(std::set<unsigned int> const& explodedMines, std::string const& playerName, std::ostream& outputStream);

--- a/include/minefield/process_round_result.h
+++ b/include/minefield/process_round_result.h
@@ -1,5 +1,5 @@
 #pragma once
 #include "minefield.h"
 
-NextState processRoundResult(GameContext &context);
-unsigned int getMaxMineCount(const std::vector<Player> &players);
+NextState processRoundResult(GameContext& context);
+unsigned int getMaxMineCount(std::vector<Player> const& players);

--- a/include/minefield/select_mines.h
+++ b/include/minefield/select_mines.h
@@ -1,11 +1,19 @@
 #pragma once
 #include "minefield.h"
-#include <vector>
-#include <random>
 
-NextState selectMines(GameContext &context);
-NextState selectGuesses(GameContext &context);
-void manualMineSelection(int selectionSize, std::vector<unsigned int> &minesVector, const std::vector<unsigned int> &availableCells, GetInputFn<unsigned int> getInput);
-void randomMineSelection(int selectionSize, std::vector<unsigned int> &randomSelection, const std::vector<unsigned int> &availableCells, const RandomGenerationFn &randomGenerator);
-void printMineSelection(const std::vector<int> &mines, const std::string &message = "");
-unsigned int getRivalsMaxMineCount(const Player &player, const std::vector<Player> &players);
+#include <random>
+#include <vector>
+
+NextState selectMines(GameContext& context);
+NextState selectGuesses(GameContext& context);
+void manualMineSelection(int selectionSize,
+    std::vector<unsigned int>& minesVector,
+    std::vector<unsigned int> const& availableCells,
+    std::ostream& outputStream,
+    GetInputFn<unsigned int> getInput);
+void randomMineSelection(int selectionSize,
+    std::vector<unsigned int>& randomSelection,
+    std::vector<unsigned int> const& availableCells,
+    RandomGenerationFn const& randomGenerator);
+void printMineSelection(std::vector<unsigned int> const& mines, std::ostream& outputStream, std::string const& message = "");
+unsigned int getRivalsMaxMineCount(Player const& player, std::vector<Player> const& players);

--- a/include/minefield/setup_game.h
+++ b/include/minefield/setup_game.h
@@ -1,8 +1,10 @@
 #pragma once
 #include "minefield.h"
 
-NextState setupGame(GameContext &context);
-int readIntInRange(unsigned int min, unsigned int max, GetInputFn<unsigned int> getInput);
-void createPlayers(GameContext &context, unsigned int humanPlayers, unsigned int computerPlayers, GetInputFn<std::string> getInput);
-
-
+NextState setupGame(GameContext& context);
+int readIntInRange(unsigned int min, unsigned int max, std::ostream& outputStream, GetInputFn<unsigned int> getInput = getInputFromCin);
+void createPlayers(GameContext& context,
+    unsigned int humanPlayers,
+    unsigned int computerPlayers,
+    std::ostream& outputStream,
+    GetInputFn<std::string> getInput = getInputFromCin);

--- a/include/minefield/shared.h
+++ b/include/minefield/shared.h
@@ -1,9 +1,9 @@
 #pragma once
-#include <random>
 #include <iostream>
+#include <random>
 
-template<typename T>
-using GetInputFn = T(*)();
+template <typename T>
+using GetInputFn = T (*)();
 
 template <typename T>
 T getInputFromCin()
@@ -18,8 +18,15 @@ T getInputFromCin()
         }
         std::cin.clear();
         std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        std::cout << "Invalid input! Try again: ";
+        //TODO
+        //printMessage("Invalid input! Try again: ");
     }
+}
+
+template <typename... Args>
+void printMessage(std::ostream& outputStream, Args&&... args)
+{
+    (outputStream << ... << args);
 }
 
 void clearStandardInput();

--- a/include/minefield/show_board.h
+++ b/include/minefield/show_board.h
@@ -1,4 +1,5 @@
 #pragma once
 #include "minefield.h"
 
-NextState showBoard(GameContext &context);
+NextState showBoard(GameContext& context);
+void printCell(std::ostream& outputStream, int cellValue);

--- a/src/minefield/exit_game.cpp
+++ b/src/minefield/exit_game.cpp
@@ -2,5 +2,5 @@
 
 NextState exitGame(GameContext&)
 {
-    return { nullptr };
+    return {nullptr};
 }

--- a/src/minefield/process_mine_detection.cpp
+++ b/src/minefield/process_mine_detection.cpp
@@ -1,29 +1,31 @@
-#include <iostream>
-#include <vector>
-#include <set>
 #include <minefield/process_mine_detection.h>
 #include <minefield/process_round_result.h>
+#include <minefield/shared.h>
 
-void printExplodedMinesMessage(const std::set<unsigned int> &explodedMines, const std::string &playerName)
+#include <iostream>
+#include <set>
+#include <vector>
+
+void printExplodedMinesMessage(std::set<unsigned int> const& explodedMines, std::string const& playerName, std::ostream& outputStream)
 {
     if (!explodedMines.empty())
     {
-        std::cout << playerName << ", you lost your mine(s) at spot(s) ";
+        printMessage(outputStream, playerName, ", you lost your mine(s) at spot(s) ");
         for (auto it = explodedMines.begin(); it != explodedMines.end(); ++it)
         {
-            std::cout << *it;
+            printMessage(outputStream, *it);
             if (std::next(it) != explodedMines.end())
             {
-                std::cout << ", ";
+                printMessage(outputStream, ", ");
             }
         }
-        std::cout << '.' << std::endl;
+        printMessage(outputStream, ".\n");
     }
 }
 
-void disableCell(std::vector<int> &cells, int cell)
+void disableCell(std::vector<int>& cells, int cell)
 {
-    static const int kDisabledCell = -1;
+    static int const kDisabledCell = -1;
     auto cellToDisable = std::find(cells.begin(), cells.end(), cell);
     if (cellToDisable != cells.end())
     {
@@ -31,7 +33,7 @@ void disableCell(std::vector<int> &cells, int cell)
     }
 }
 
-void disableUsedCells(std::unordered_set<unsigned int> usedCells, Board &board)
+void disableUsedCells(std::unordered_set<unsigned int> usedCells, Board& board)
 {
     for (unsigned int cell : usedCells)
     {
@@ -40,7 +42,7 @@ void disableUsedCells(std::unordered_set<unsigned int> usedCells, Board &board)
     }
 }
 
-void resizePlayerMineCount(std::unordered_map<Player *, int> playerExplodedMineCount)
+void resizePlayerMineCount(std::unordered_map<Player*, int> playerExplodedMineCount)
 {
     for (auto [playerPtr, count] : playerExplodedMineCount)
     {
@@ -51,7 +53,7 @@ void resizePlayerMineCount(std::unordered_map<Player *, int> playerExplodedMineC
     }
 }
 
-std::set<unsigned int> getExplodedMines(const std::vector<unsigned int> &minesToCheck, const std::vector<unsigned int> &minesToMatchAgainst)
+std::set<unsigned int> getExplodedMines(std::vector<unsigned int> const& minesToCheck, std::vector<unsigned int> const& minesToMatchAgainst)
 {
     std::set<unsigned int> explodedMines;
 
@@ -68,15 +70,15 @@ std::set<unsigned int> getExplodedMines(const std::vector<unsigned int> &minesTo
     return explodedMines;
 }
 
-NextState processMineDetection(GameContext &context)
+NextState processMineDetection(GameContext& context)
 {
     std::unordered_set<unsigned int> boardUsedCells;
-    std::unordered_map<Player *, int> playerExplodedMineCount;
+    std::unordered_map<Player*, int> playerExplodedMineCount;
 
-    for (Player &player : context.players)
+    for (Player& player : context.players)
     {
         std::set<unsigned int> explodedMines = getExplodedMines(player.mines, player.guesses); // self hits
-        for (Player &rival : context.players)
+        for (Player& rival : context.players)
         {
             if (&player != &rival)
             {
@@ -88,7 +90,7 @@ NextState processMineDetection(GameContext &context)
             }
         }
 
-        printExplodedMinesMessage(explodedMines, player.name);
+        printExplodedMinesMessage(explodedMines, player.name, context.outputStream);
 
         for (unsigned int cell : player.mines)
         {

--- a/src/minefield/process_round_result.cpp
+++ b/src/minefield/process_round_result.cpp
@@ -1,12 +1,14 @@
-#include <iostream>
-#include <minefield/minefield.h>
 #include <minefield/exit_game.h>
+#include <minefield/minefield.h>
+#include <minefield/shared.h>
 #include <minefield/show_board.h>
 
-unsigned int getMaxMineCount(const std::vector<Player> &players)
+#include <iostream>
+
+unsigned int getMaxMineCount(std::vector<Player> const& players)
 {
     unsigned int max = 0;
-    for (const Player &player : players)
+    for (Player const& player : players)
     {
         if (player.mines.size() > max)
         {
@@ -16,12 +18,14 @@ unsigned int getMaxMineCount(const std::vector<Player> &players)
     return max;
 }
 
-NextState processRoundResult(GameContext &context)
+NextState processRoundResult(GameContext& context)
 {
     unsigned int maxMineCount = getMaxMineCount(context.players);
     if (maxMineCount > context.board.availableCells.size())
     {
-        std::cout << "It looks like the available cells on the board are not enough to keep playing. We'll have to call it a tie between the remaining players and start over!" << std::endl;
+        printMessage(context.outputStream,
+            "It looks like the available cells on the board are not enough to keep playing. We'll have to call it a tie between the remaining players and "
+            "start over!\n");
         return {&exitGame};
     }
 
@@ -29,7 +33,7 @@ NextState processRoundResult(GameContext &context)
     {
         if (iterator->mines.empty())
         {
-            std::cout << iterator->name << " got completely mined out!" << std::endl;
+            printMessage(context.outputStream, iterator->name, " got completely mined out!\n");
             iterator = context.players.erase(iterator);
         }
         else
@@ -40,17 +44,17 @@ NextState processRoundResult(GameContext &context)
 
     if (context.players.empty())
     {
-        std::cout << "A perfect tie, in total destruction. No mines, no survivors!" << std::endl;
+        printMessage(context.outputStream, "A perfect tie, in total destruction. No mines, no survivors!\n");
         return {&exitGame};
     }
     else if (context.players.size() == 1)
     {
-        std::cout << context.players[0].name << " takes the crown! The sole survivor of the minefield!" << std::endl;
+        printMessage(context.outputStream, context.players[0].name, " takes the crown! The sole survivor of the minefield!\n");
         return {&exitGame};
     }
     else
     {
-        std::cout << context.players.size() << " players still in the game. Next round begins!" << std::endl;
+        printMessage(context.outputStream, context.players.size(), " players still in the game. Next round begins!\n");
         return {&showBoard};
     }
 }

--- a/src/minefield/select_mines.cpp
+++ b/src/minefield/select_mines.cpp
@@ -1,24 +1,28 @@
-#include <iostream>
-#include <vector>
-#include <random>
-#include <string>
-#include <minefield/minefield.h>
-#include <minefield/select_mines.h>
-#include <minefield/process_mine_detection.h>
 #include <minefield/exit_game.h>
+#include <minefield/minefield.h>
+#include <minefield/process_mine_detection.h>
+#include <minefield/select_mines.h>
 #include <minefield/shared.h>
 
-void printMineSelection(const std::vector<unsigned int> &mines, const std::string &message = "")
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+void printMineSelection(std::vector<unsigned int> const& mines, std::ostream& outputStream, std::string const& message)
 {
-    std::cout << message << std::endl;
+    printMessage(outputStream, message);
     for (int mine : mines)
     {
-        std::cout << mine << ' ';
+        printMessage(outputStream, mine, ' ');
     }
-    std::cout << std::endl;
+    printMessage(outputStream, "\n");
 }
 
-void randomMineSelection(int selectionSize, std::vector<unsigned int> &randomSelection, const std::vector<unsigned int> &availableCells, const RandomGenerationFn &randomGenerator)
+void randomMineSelection(int selectionSize,
+    std::vector<unsigned int>& randomSelection,
+    std::vector<unsigned int> const& availableCells,
+    RandomGenerationFn const& randomGenerator)
 {
     randomSelection.clear();
     while (randomSelection.size() < selectionSize)
@@ -32,7 +36,11 @@ void randomMineSelection(int selectionSize, std::vector<unsigned int> &randomSel
     }
 }
 
-void manualMineSelection(int selectionSize, std::vector<unsigned int> &minesVector, const std::vector<unsigned int> &availableCells, GetInputFn<unsigned int> getInput)
+void manualMineSelection(int selectionSize,
+    std::vector<unsigned int>& minesVector,
+    std::vector<unsigned int> const& availableCells,
+    std::ostream& outputStream,
+    GetInputFn<unsigned int> getInput)
 {
     minesVector.clear();
     for (int i = 0; i < selectionSize; ++i)
@@ -42,18 +50,18 @@ void manualMineSelection(int selectionSize, std::vector<unsigned int> &minesVect
 
         while (!validSelectedCell)
         {
-            std::cout << "Enter cell #" << (i + 1) << ": ";
+            printMessage(outputStream, "Enter cell #", (i + 1), ": ");
             selectedCell = getInput();
 
             if (std::find(availableCells.begin(), availableCells.end(), selectedCell) == availableCells.end())
             {
-                std::cout << "Cell " << selectedCell << " is disabled! Please choose another one" << std::endl;
+                printMessage(outputStream, "Cell ", selectedCell, " is disabled! Please choose another one\n");
                 continue;
             }
 
             if (std::find(minesVector.begin(), minesVector.end(), selectedCell) != minesVector.end())
             {
-                std::cout << "You already picked cell " << selectedCell << ". Please choose a different one!" << std::endl;
+                printMessage(outputStream, "You already picked cell ", std::to_string(selectedCell), ". Please choose a different one!\n");
                 continue;
             }
 
@@ -64,34 +72,34 @@ void manualMineSelection(int selectionSize, std::vector<unsigned int> &minesVect
     }
 }
 
-unsigned int getRivalsMaxMineCount(const Player &player, const std::vector<Player> &players)
+unsigned int getRivalsMaxMineCount(Player const& player, std::vector<Player> const& players)
 {
     unsigned int max = 0;
-    for (const Player &rivalPlayer : players)
+    for (Player const& rivalPlayer : players)
     {
         if (&rivalPlayer != &player && rivalPlayer.mines.size() > max)
         {
-
             max = rivalPlayer.mines.size();
         }
     }
     return max;
 }
 
-NextState selectGuesses(GameContext &context)
+NextState selectGuesses(GameContext& context)
 {
-    std::cout << "Alright, it's time to strike!" << std::endl;
-    std::cout << "Remember: if you pick the spots where you hid your own mines, you'll blow up your stash!" << std::endl;
-    for (Player &player : context.players)
+    printMessage(
+        context.outputStream, "Alright, it's time to strike!\nRemember: if you pick the spots where you hid your own mines, you'll blow up your stash!\n");
+    for (Player& player : context.players)
     {
         unsigned int minesToGuess = getRivalsMaxMineCount(player, context.players);
         if (player.type == PlayerType::Human)
         {
-            std::cout << player.name << ", just so you don't trip over your own traps: your mines are in spots ";
-            printMineSelection(player.mines);
+            printMessage(context.outputStream, player.name, ", just so you don't trip over your own traps: your mines are in spots ");
+            printMineSelection(player.mines, context.outputStream);
 
-            std::cout << "You've got " << minesToGuess << " guess(es) --just as many as the mines your most dangerous rival has left. Where will you shoot?" << std::endl;
-            manualMineSelection(minesToGuess, player.guesses, context.board.availableCells, getInputFromCin);
+            printMessage(context.outputStream, "\nYou've got ", minesToGuess,
+                " guess(es) --just as many as the mines your most dangerous rival has left. Where will you shoot?\n");
+            manualMineSelection(minesToGuess, player.guesses, context.board.availableCells, context.outputStream, getInputFromCin);
         }
         else
         {
@@ -104,14 +112,14 @@ NextState selectGuesses(GameContext &context)
     return {&processMineDetection};
 }
 
-NextState selectMines(GameContext &context)
+NextState selectMines(GameContext& context)
 {
-    for (Player &player : context.players)
+    for (Player& player : context.players)
     {
         if (player.type == PlayerType::Human)
         {
-            std::cout << player.name << " it's your turn! Pick " << player.mines.size() << " spot(s) to hide your mine(s)" << std::endl;
-            manualMineSelection(player.mines.size(), player.mines, context.board.availableCells, getInputFromCin);
+            printMessage(context.outputStream, player.name, " it's your turn! Pick ", player.mines.size(), " spot(s) to hide your mine(s)\n");
+            manualMineSelection(player.mines.size(), player.mines, context.board.availableCells, context.outputStream, getInputFromCin);
         }
         else
         {

--- a/src/minefield/setup_game.cpp
+++ b/src/minefield/setup_game.cpp
@@ -1,10 +1,12 @@
 #include <minefield/minefield.h>
+#include <minefield/setup_game.h>
 #include <minefield/shared.h>
 #include <minefield/show_board.h>
+
 #include <iostream>
 #include <limits>
 
-int readIntInRange(unsigned int min, unsigned int max, GetInputFn<unsigned int> getInput)
+int readIntInRange(unsigned int min, unsigned int max, std::ostream& outputStream, GetInputFn<unsigned int> getInput)
 {
     unsigned int input = 0;
     bool validInput = false;
@@ -15,13 +17,13 @@ int readIntInRange(unsigned int min, unsigned int max, GetInputFn<unsigned int> 
         validInput = input >= min && input <= max;
         if (!validInput)
         {
-            std::cout << "Too wild! Choose something in the safe zone: " << min << " to " << max << std::endl;
+            printMessage(outputStream, "Too wild! Choose something in the safe zone: ", min, " to ", max, "\n");
         }
     }
     return input;
 }
 
-void createPlayers(GameContext& context, unsigned int humanPlayers, unsigned int computerPlayers, GetInputFn<std::string> getInput)
+void createPlayers(GameContext& context, unsigned int humanPlayers, unsigned int computerPlayers, std::ostream& outputStream, GetInputFn<std::string> getInput)
 {
     context.players.clear();
     std::vector<std::string> usedNames;
@@ -34,13 +36,13 @@ void createPlayers(GameContext& context, unsigned int humanPlayers, unsigned int
 
         while (!validName)
         {
-            std::cout << "What's the name of human player #" << playerNumber << "? ";
+            printMessage(outputStream, "What's the name of human player #", playerNumber, "? ");
             name = getInput();
 
             validName = std::find(usedNames.begin(), usedNames.end(), name) == usedNames.end();
             if (!validName)
             {
-                std::cout << "That name already exists. Please choose a different one!";
+                printMessage(outputStream, "That name already exists. Please choose a different one!\n");
             }
             else
             {
@@ -61,7 +63,7 @@ void createPlayers(GameContext& context, unsigned int humanPlayers, unsigned int
         Player player;
         player.name = "Computer_" + std::to_string(i + 1);
         player.type = PlayerType::Computer;
-        std::cout << "Our creative team (the compiler) named computer player #" << playerNumber << ": " << player.name << std::endl;
+        printMessage(outputStream, "Our creative team (the compiler) named computer player #", playerNumber, ": ", player.name, "\n");
         context.players.push_back(player);
         ++playerNumber;
     }
@@ -69,28 +71,27 @@ void createPlayers(GameContext& context, unsigned int humanPlayers, unsigned int
 
 NextState setupGame(GameContext& context)
 {
-    std::cout << "=================================" << std::endl;
-    std::cout << "Welcome to Minefield, brave soul!" << std::endl;
-    std::cout << "=================================" << std::endl;
-    std::cout << "Let's start defining the basics of the game" << std::endl;
+    printMessage(context.outputStream,
+        "=================================\nWelcome to Minefield, brave soul!\n=================================\nLet's start defining the basics of the "
+        "game\n");
 
-    std::cout << "First things first: how many human players will be joining the game? (up to 5!)" << std::endl;
-    int humanPlayers = readIntInRange(1, 5, getInputFromCin);
+    printMessage(context.outputStream, "First things first: how many human players will be joining the game? (up to 5!)\n");
+    int humanPlayers = readIntInRange(1, 5, context.outputStream);
 
-    std::cout << "And how many fearless computer-controlled players shall we unleash? (again, no more than 5)" << std::endl;
-    int computerPlayers = readIntInRange(0, 5, getInputFromCin);
+    printMessage(context.outputStream, "And how many fearless computer-controlled players shall we unleash? (again, no more than 5)\n");
+    int computerPlayers = readIntInRange(0, 5, context.outputStream);
 
-    std::cout << "Perfect! That makes us " << humanPlayers + computerPlayers << ". Now, to keep things organized, let's name our heroes." << std::endl;
-    createPlayers(context, humanPlayers, computerPlayers, getInputFromCin);
+    printMessage(context.outputStream, "Perfect! That makes us ", (humanPlayers + computerPlayers), ". Now, to keep things organized, let's name our heroes\n");
+    createPlayers(context, humanPlayers, computerPlayers, context.outputStream);
 
-    std::cout << "Let's craft the board now. How many tiles across? (it should be a number between 24 and 50)" << std::endl;
-    context.board.width = readIntInRange(24, 50, getInputFromCin);
+    printMessage(context.outputStream, "Let's craft the board now. How many tiles across? (it should be a number between 24 and 50)\n");
+    context.board.width = readIntInRange(24, 50, context.outputStream);
 
-    std::cout << "Now, how many tiles from top to bottom? (again, between 24 and 50)" << std::endl;
-    context.board.height = readIntInRange(24, 50, getInputFromCin);
+    printMessage(context.outputStream, "Now, how many tiles from top to bottom? (again, between 24 and 50)\n");
+    context.board.height = readIntInRange(24, 50, context.outputStream);
 
-    std::cout << "Final step: how many mines should we drop? (let's say, between 3 and 8)" << std::endl;
-    context.board.initialMines = readIntInRange(3, 8, getInputFromCin);
+    printMessage(context.outputStream, "Final step: how many mines should we drop? (let's say, between 3 and 8)\n");
+    context.board.initialMines = readIntInRange(3, 8, context.outputStream);
 
     for (Player& player : context.players)
     {

--- a/src/minefield/shared.cpp
+++ b/src/minefield/shared.cpp
@@ -1,4 +1,5 @@
 #include <minefield/shared.h>
+
 #include <iostream>
 #include <random>
 

--- a/src/minefield/show_board.cpp
+++ b/src/minefield/show_board.cpp
@@ -1,21 +1,28 @@
 #include <minefield/minefield.h>
 #include <minefield/select_mines.h>
+#include <minefield/shared.h>
+#include <minefield/show_board.h>
 
 #include <iomanip>
 #include <iostream>
 
+void printCell(std::ostream& outputStream, int cellValue)
+{
+    outputStream << std::setw(3) << cellValue << " ";
+}
+
 NextState showBoard(GameContext& context)
 {
-    std::cout << "What a battlefield! Hide your mines carefully --but remember, tiles marked with -1 are disabled!" << std::endl;
+    printMessage(context.outputStream, "What a battlefield! Hide your mines carefully --but remember, tiles marked with -1 are disabled!\n");
 
     for (int i = 0; i < context.board.boardCells.size(); ++i)
     {
         if (i % context.board.width == 0)
         {
-            std::cout << std::endl;
+            printMessage(context.outputStream, "\n");
         }
-        std::cout << std::setw(3) << context.board.boardCells[i] << " ";
+        printCell(context.outputStream, context.board.boardCells[i]);
     }
-    std::cout << std::endl;
+    printMessage(context.outputStream, "\n");
     return {&selectMines};
 }


### PR DESCRIPTION
This PR replaces all direct std::cout calls with printMessage, which takes a std::ostream& parameter. To allow setting this parameter in tests (e.g., using a NullStream to suppress console output), an outputStream attribute was added to the GameContext struct.
