### PR TITLE
ISSUE_10 Remove disableCell function from the header file

### DIFF
--- a/include/minefield/process_mine_detection.h
+++ b/include/minefield/process_mine_detection.h
@@ -9,6 +9,5 @@
 NextState processMineDetection(GameContext& context);
 std::set<unsigned int> getExplodedMines(std::vector<unsigned int> const& minesToCheck, std::vector<unsigned int> const& minesToMatchAgainst);
 void disableUsedCells(std::unordered_set<unsigned int> usedCells, Board& board);
-void disableCell(std::vector<int>& cells, int cell);
 void resizePlayerMineCount(std::unordered_map<Player*, int> playerExplodedMineCount);
 void printExplodedMinesMessage(std::set<unsigned int> const& explodedMines, std::string const& playerName, std::ostream& outputStream);


### PR DESCRIPTION
Fix for [issue#10](https://github.com/AgustinaSbergamo/minefield_vs/issues/10): while the disableCell function does set the value of the cell to kDisabledCell, it does not disable the cell by itself, since the code to remove the cell from the availableCells vector is in the disableUsedCells function.

The disableCell function was not intended for public access, so it has been removed from the API.
