### PR TITLE
ISSUE_8 Clear boardCells and availableCells vectors before populating

### DIFF
--- a/src/minefield/setup_game.cpp
+++ b/src/minefield/setup_game.cpp
@@ -10,7 +10,7 @@ int readIntInRange(unsigned int min, unsigned int max, GameContext::IO& io, GetI
 {
     unsigned int input = 0;
     bool validInput = false;
-    
+
     if (min > max)
     {
         std::swap(min, max);
@@ -105,6 +105,8 @@ NextState setupGame(GameContext& context)
         player.guesses = std::vector<unsigned int>(context.board.initialMines);
     }
 
+    context.board.boardCells.clear();
+    context.board.availableCells.clear();
     for (int i = 0; i < context.board.width * context.board.height; i++)
     {
         context.board.boardCells.push_back(i + 1);


### PR DESCRIPTION
Fix to [issue#8](https://github.com/AgustinaSbergamo/minefield_vs/issues/8): when calling setupGame with a context that has been already set up once, the old values will be reset except for the boardCells and availableCells vectors. Meaning that cells will be added to the board on top of the ones that were already stored in it.

This PR clears boardCells and availableCells vectors before populating. 